### PR TITLE
Relative URLs & ability to optionally not set an info window adapter

### DIFF
--- a/library/src/com/google/maps/android/data/Renderer.java
+++ b/library/src/com/google/maps/android/data/Renderer.java
@@ -103,12 +103,24 @@ public class Renderer {
     private final GeoJsonPolygonStyle mDefaultPolygonStyle;
 
     /**
-     * Creates a new Renderer object
+     * Creates a new Renderer object with the default info window adapter.
      *
      * @param map map to place objects on
      * @param context context needed to add info windows
      */
     public Renderer(GoogleMap map, Context context) {
+        //This constructor is left for backwards compatibility.
+        this(map, context, true);
+    }
+    /**
+     * Creates a new Renderer object, and optionally sets the default info window adapter.
+     *
+     * @param map map to place objects on
+     * @param context context needed to add info windows
+     * @param setDefaultInfoWindowAdapter true to set the given map's info window adapter to one that displays a title and snippet,
+     *                                  or false to not set it (used to prevent this class from overriding your own custom adapter).
+     */
+    public Renderer(GoogleMap map, Context context, boolean setDefaultInfoWindowAdapter) {
         mMap = map;
         mContext = context;
         mLayerOnMap = false;
@@ -119,6 +131,10 @@ public class Renderer {
         mDefaultLineStringStyle = null;
         mDefaultPolygonStyle = null;
         mContainerFeatures = new BiMultiMap<>();
+
+        if (setDefaultInfoWindowAdapter) {
+            setDefaultInfoWindowAdapter();
+        }
     }
 
     /**
@@ -871,28 +887,23 @@ public class Renderer {
         boolean hasBalloonText = style.getBalloonOptions().containsKey("text");
         if (hasBalloonOptions && hasBalloonText) {
             marker.setTitle(style.getBalloonOptions().get("text"));
-            createInfoWindow();
         } else if (hasBalloonOptions && hasName) {
             marker.setTitle(placemark.getProperty("name"));
-            createInfoWindow();
         } else if (hasName && hasDescription) {
             marker.setTitle(placemark.getProperty("name"));
             marker.setSnippet(placemark.getProperty("description"));
-            createInfoWindow();
         } else if (hasDescription) {
             marker.setTitle(placemark.getProperty("description"));
-            createInfoWindow();
         } else if (hasName) {
             marker.setTitle(placemark.getProperty("name"));
-            createInfoWindow();
         }
     }
 
     /**
-     * Creates a new InfoWindowAdapter and sets text if marker snippet or title is set. This allows
+     * Sets a default InfoWindowAdapter on the map that sets text if marker snippet or title is set. This allows
      * the info window to have custom HTML.
      */
-    private void createInfoWindow() {
+    private void setDefaultInfoWindowAdapter() {
         mMap.setInfoWindowAdapter(new GoogleMap.InfoWindowAdapter() {
 
             public View getInfoWindow(Marker arg0) {

--- a/library/src/com/google/maps/android/data/kml/KmlLayer.java
+++ b/library/src/com/google/maps/android/data/kml/KmlLayer.java
@@ -2,6 +2,8 @@ package com.google.maps.android.data.kml;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.maps.android.data.Layer;
+import com.google.maps.android.data.Renderer;
+
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -16,17 +18,41 @@ import java.io.InputStream;
  */
 public class KmlLayer extends Layer {
 
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, int, Context, String, boolean)} but with a null directoryName
+     * and and will use the default info window adapter.
+     */
+    public KmlLayer(GoogleMap map, int resourceId, Context context)
+            throws XmlPullParserException, IOException {
+        this(map, resourceId, context, null, true);
+    }
+
+
+    /**
+     * Same as {@link KmlLayer#KmlLayer(GoogleMap, InputStream, Context, String, boolean)} but with a null directoryName
+     * and will use the default info window adapter.
+     */
+    public KmlLayer(GoogleMap map, InputStream stream, Context context)
+            throws XmlPullParserException, IOException {
+        this(map, stream, context, null, true);
+    }
+
+
     /**
      * Creates a new KmlLayer object - addLayerToMap() must be called to trigger rendering onto a map.
      *
      * @param map        GoogleMap object
      * @param resourceId Raw resource KML file
      * @param context    Context object
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
+     * @param setDefaultInfoWindowAdapter See {@link Renderer#Renderer(GoogleMap, Context, boolean)} docs.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, int resourceId, Context context)
+    public KmlLayer(GoogleMap map, int resourceId, Context context, String directoryName, boolean setDefaultInfoWindowAdapter)
             throws XmlPullParserException, IOException {
-        this(map, context.getResources().openRawResource(resourceId), context);
+        this(map, context.getResources().openRawResource(resourceId), context, directoryName, setDefaultInfoWindowAdapter);
     }
 
     /**
@@ -34,14 +60,17 @@ public class KmlLayer extends Layer {
      *
      * @param map    GoogleMap object
      * @param stream InputStream containing KML file
+     * @param directoryName the fully qualified directory name to look in (in the android file
+     *                      system) for any relative-path images, or null to only look online.
+     * @param setDefaultInfoWindowAdapter See {@link Renderer#Renderer(GoogleMap, Context, boolean)} docs.
      * @throws XmlPullParserException if file cannot be parsed
      */
-    public KmlLayer(GoogleMap map, InputStream stream, Context context)
+    public KmlLayer(GoogleMap map, InputStream stream, Context context, String directoryName, boolean setDefaultInfoWindowAdapter)
             throws XmlPullParserException, IOException {
         if (stream == null) {
             throw new IllegalArgumentException("KML InputStream cannot be null");
         }
-        KmlRenderer mRenderer = new KmlRenderer(map, context);
+        KmlRenderer mRenderer = new KmlRenderer(map, context, directoryName, setDefaultInfoWindowAdapter);
         XmlPullParser xmlPullParser = createXmlParser(stream);
         KmlParser parser = new KmlParser(xmlPullParser);
         parser.parseKml();


### PR DESCRIPTION
`Renderer.createInfoWindow()` was calling `mMap.setInfoWindowAdapter`, overriding any custom info window adapter that the user might have set. I added the ability to construct a KmlLayer with a boolean parameter that will tell the library to not set that default info window adapter.

Everything was made backwards compatible by leaving the original constructors intact.